### PR TITLE
fix: replace eslint-plugin-import-x with eslint-plugin-import-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -494,7 +494,7 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
             "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.0",
@@ -505,7 +505,7 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
             "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.0"
@@ -515,7 +515,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
             "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.0"
@@ -624,6 +624,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
             "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -681,6 +682,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
             "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.4"
@@ -693,6 +695,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
             "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/@jest/diff-sequences": {
@@ -828,6 +831,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
             "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "agent-base": "^7.1.0",
@@ -844,6 +848,7 @@
             "version": "9.4.2",
             "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.4.2.tgz",
             "integrity": "sha512-omJgPyzt11cEGrxzgrECoOyxAunmPMgBFTcAB/FbaB+9iOYhGmRdsQqySV8o0LWQ/l2kTeASUIMR4xJufVwmtw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.0",
@@ -892,6 +897,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
             "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "semver": "^7.3.5"
@@ -904,6 +910,7 @@
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
             "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.0",
@@ -923,6 +930,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
             "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=20"
@@ -932,6 +940,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
             "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^4.0.0"
@@ -947,6 +956,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
             "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-bundled": "^5.0.0",
@@ -963,6 +973,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
             "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/name-from-folder": "^4.0.0",
@@ -978,6 +989,7 @@
             "version": "9.0.3",
             "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
             "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cacache": "^20.0.0",
@@ -994,6 +1006,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
             "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -1003,6 +1016,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
             "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -1012,6 +1026,7 @@
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
             "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/git": "^7.0.0",
@@ -1030,6 +1045,7 @@
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
             "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "which": "^6.0.0"
@@ -1042,6 +1058,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
             "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=20"
@@ -1051,6 +1068,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
             "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^4.0.0"
@@ -1066,6 +1084,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
             "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "postcss-selector-parser": "^7.0.0"
@@ -1078,6 +1097,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
             "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -1087,6 +1107,7 @@
             "version": "10.0.4",
             "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
             "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/node-gyp": "^5.0.0",
@@ -1405,12 +1426,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             }
-        },
-        "node_modules/@package-json/types": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
-            "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
-            "license": "MIT"
         },
         "node_modules/@pnpm/config.env-replace": {
             "version": "1.1.0",
@@ -2363,6 +2378,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
             "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/protobuf-specs": "^0.5.0"
@@ -2375,6 +2391,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.0.tgz",
             "integrity": "sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA==",
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -2384,6 +2401,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.0.tgz",
             "integrity": "sha512-MM8XIwUjN2bwvCg1QvrMtbBmpcSHrkhFSCu1D11NyPvDQ25HEc4oG5/OcQfd/Tlf/OxmKWERDj0zGE23jQaMwA==",
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
@@ -2393,6 +2411,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
             "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.2",
@@ -2410,6 +2429,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
             "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/protobuf-specs": "^0.5.0",
@@ -2423,6 +2443,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.0.tgz",
             "integrity": "sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/bundle": "^4.0.0",
@@ -2586,6 +2607,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
             "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
@@ -2595,6 +2617,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
             "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@tufjs/canonical-json": "2.0.0",
@@ -2894,278 +2917,6 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-            "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-android-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-            "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-darwin-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-            "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-darwin-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-            "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-freebsd-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-            "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-            "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-            "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-            "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-            "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-            "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-            "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-            "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-            "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-            "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-            "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-            "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
-            "cpu": [
-                "wasm32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@napi-rs/wasm-runtime": "^0.2.11"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "^1.4.3",
-                "@emnapi/runtime": "^1.4.3",
-                "@tybys/wasm-util": "^0.10.0"
-            }
-        },
-        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-            "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-            "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-            "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
         "node_modules/@vitest/expect": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
@@ -3317,6 +3068,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
             "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -3574,6 +3326,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
             "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cmd-shim": "^8.0.0",
@@ -3729,6 +3482,7 @@
             "version": "20.0.4",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
             "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/fs": "^5.0.0",
@@ -3835,6 +3589,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
             "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
@@ -4019,6 +3774,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
             "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -4055,19 +3811,11 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/comment-parser": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
-            "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12.0.0"
-            }
-        },
         "node_modules/common-ancestor-path": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
             "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">= 18"
@@ -4943,65 +4691,16 @@
                 }
             }
         },
-        "node_modules/eslint-import-context": {
-            "version": "0.1.9",
-            "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
-            "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+        "node_modules/eslint-plugin-import-lite": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import-lite/-/eslint-plugin-import-lite-0.6.0.tgz",
+            "integrity": "sha512-80vevx2A7i3H7n1/6pqDO8cc5wRz6OwLDvIyVl9UflBV1N1f46e9Ihzi65IOLYoSxM6YykK2fTw1xm0Ixx6aTQ==",
             "license": "MIT",
-            "dependencies": {
-                "get-tsconfig": "^4.10.1",
-                "stable-hash-x": "^0.2.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint-import-context"
-            },
-            "peerDependencies": {
-                "unrs-resolver": "^1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "unrs-resolver": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/eslint-plugin-import-x": {
-            "version": "4.16.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
-            "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
-            "license": "MIT",
-            "dependencies": {
-                "@package-json/types": "^0.0.12",
-                "@typescript-eslint/types": "^8.56.0",
-                "comment-parser": "^1.4.1",
-                "debug": "^4.4.1",
-                "eslint-import-context": "^0.1.9",
-                "is-glob": "^4.0.3",
-                "minimatch": "^9.0.3 || ^10.1.2",
-                "semver": "^7.7.2",
-                "stable-hash-x": "^0.2.0",
-                "unrs-resolver": "^1.9.2"
-            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
-            "funding": {
-                "url": "https://opencollective.com/eslint-plugin-import-x"
-            },
             "peerDependencies": {
-                "@typescript-eslint/utils": "^8.56.0",
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "eslint-import-resolver-node": "*"
-            },
-            "peerDependenciesMeta": {
-                "@typescript-eslint/utils": {
-                    "optional": true
-                },
-                "eslint-import-resolver-node": {
-                    "optional": true
-                }
+                "eslint": "^9.0.0 || ^10.0.0"
             }
         },
         "node_modules/eslint-plugin-unicorn": {
@@ -5239,6 +4938,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
             "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/fast-content-type-parse": {
@@ -5631,6 +5331,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
             "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
@@ -5754,6 +5455,7 @@
             "version": "4.13.6",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
             "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -5798,6 +5500,7 @@
             "version": "13.0.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
             "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "minimatch": "^10.2.2",
@@ -6011,6 +5714,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
             "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy-agent": {
@@ -6068,6 +5772,7 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
             "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -6115,6 +5820,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
             "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minimatch": "^10.0.3"
@@ -6226,6 +5932,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
             "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -6252,6 +5959,7 @@
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
             "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -6545,6 +6253,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
             "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -6566,6 +6275,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
             "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
+            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -6614,6 +6324,7 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
             "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+            "dev": true,
             "engines": [
                 "node >= 0.2.0"
             ],
@@ -6623,12 +6334,14 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
             "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/just-diff-apply": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
             "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/keyv": {
@@ -6657,6 +6370,7 @@
             "version": "9.1.5",
             "resolved": "https://registry.npmjs.org/libnpmpack/-/libnpmpack-9.1.5.tgz",
             "integrity": "sha512-H1IX364ZwpeRfrL6UYSuxFNgP16/TvlwtCm8ZallbB7/1FZ3h1FBZHamQtv7PqcZUTWE27mygdQ4wCCW2BmVlg==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/arborist": "^9.4.2",
@@ -6672,6 +6386,7 @@
             "version": "11.1.3",
             "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-11.1.3.tgz",
             "integrity": "sha512-NVPTth/71cfbdYHqypcO9Lt5WFGTzFEcx81lWd7GDJIgZ95ERdYHGUfCtFejHCyqodKsQkNEx2JCkMpreDty/A==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/package-json": "^7.0.0",
@@ -7164,6 +6879,7 @@
             "version": "15.0.5",
             "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
             "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.0",
@@ -7383,6 +7099,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
             "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -7392,6 +7109,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
             "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
@@ -7404,6 +7122,7 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
             "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "minipass": "^7.0.3",
@@ -7421,6 +7140,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
             "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -7433,6 +7153,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7445,12 +7166,14 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/minipass-pipeline": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
             "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^3.0.0"
@@ -7463,6 +7186,7 @@
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
             "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -7475,12 +7199,14 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/minipass-sized": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
             "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.1.2"
@@ -7493,6 +7219,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
             "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "minipass": "^7.1.2"
@@ -7538,21 +7265,6 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/napi-postinstall": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
-            "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
-            "license": "MIT",
-            "bin": {
-                "napi-postinstall": "lib/cli.js"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/napi-postinstall"
-            }
-        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7563,6 +7275,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
             "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -7609,6 +7322,7 @@
             "version": "12.2.0",
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
             "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
@@ -7633,6 +7347,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
             "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=20"
@@ -7642,6 +7357,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
             "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^4.0.0"
@@ -7670,6 +7386,7 @@
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
             "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "abbrev": "^4.0.0"
@@ -7868,6 +7585,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
             "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-normalize-package-bin": "^5.0.0"
@@ -7880,6 +7598,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
             "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "semver": "^7.1.1"
@@ -7892,6 +7611,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
             "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -7901,6 +7621,7 @@
             "version": "13.0.2",
             "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
             "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "hosted-git-info": "^9.0.0",
@@ -7916,6 +7637,7 @@
             "version": "10.0.4",
             "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
             "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "ignore-walk": "^8.0.0",
@@ -7929,6 +7651,7 @@
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
             "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "npm-install-checks": "^8.0.0",
@@ -7944,6 +7667,7 @@
             "version": "19.1.1",
             "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
             "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@npmcli/redact": "^4.0.0",
@@ -10072,6 +9796,7 @@
             "version": "21.5.0",
             "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.0.tgz",
             "integrity": "sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.0",
@@ -10115,6 +9840,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
             "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "json-parse-even-better-errors": "^5.0.0",
@@ -10214,6 +9940,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
             "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^11.0.0",
@@ -10470,6 +10197,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
             "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -10486,6 +10214,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
             "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -10495,6 +10224,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
             "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
+            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -10504,6 +10234,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
             "integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
+            "dev": true,
             "license": "ISC",
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -10604,6 +10335,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
             "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -10759,6 +10491,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
             "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10927,6 +10660,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -11517,6 +11251,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.0.tgz",
             "integrity": "sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@sigstore/bundle": "^4.0.0",
@@ -11547,6 +11282,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0",
@@ -11566,6 +11302,7 @@
             "version": "2.8.7",
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
             "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ip-address": "^10.0.1",
@@ -11580,6 +11317,7 @@
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
@@ -11649,6 +11387,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
             "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
@@ -11682,21 +11421,13 @@
             "version": "13.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
             "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/stable-hash-x": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
-            "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
             }
         },
         "node_modules/stackback": {
@@ -11897,6 +11628,7 @@
             "version": "7.5.11",
             "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
             "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
@@ -12155,6 +11887,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
             "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -12257,13 +11990,14 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "devOptional": true,
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tuf-js": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
             "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@tufjs/models": "4.1.0",
@@ -12456,40 +12190,6 @@
                 "node": ">= 10.0.0"
             }
         },
-        "node_modules/unrs-resolver": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-            "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "napi-postinstall": "^0.3.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/unrs-resolver"
-            },
-            "optionalDependencies": {
-                "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-                "@unrs/resolver-binding-android-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-x64": "1.11.1",
-                "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-                "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-                "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
-            }
-        },
         "node_modules/unrun": {
             "version": "0.2.32",
             "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.32.tgz",
@@ -12598,6 +12298,7 @@
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
             "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -13125,6 +12826,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
             "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "20 || >=22"
@@ -13255,6 +12957,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
             "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "signal-exit": "^4.0.1"
@@ -13267,6 +12970,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -13307,6 +13011,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
             "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
@@ -13385,7 +13090,7 @@
         "packages/commitlint-config": {
             "name": "@tada5hi/commitlint-config",
             "version": "1.3.1",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@commitlint/config-conventional": "^20.4.4"
             },
@@ -13399,12 +13104,12 @@
         "packages/eslint-config": {
             "name": "@tada5hi/eslint-config",
             "version": "2.0.1",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@antfu/install-pkg": "^1.1.0",
                 "@eslint/js": "^10.0.1",
                 "@stylistic/eslint-plugin": "^5.10.0",
-                "eslint-plugin-import-x": "^4.0.0",
+                "eslint-plugin-import-lite": "^0.6.0",
                 "eslint-plugin-unicorn": "^63.0.0",
                 "globals": "^17.4.0",
                 "smob": "^1.6.1"
@@ -13430,7 +13135,7 @@
         "packages/eslint-config-typescript": {
             "name": "@tada5hi/eslint-config-typescript",
             "version": "2.0.1",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@tada5hi/eslint-config": "^2.0.1",
                 "typescript-eslint": "^8.57.0"
@@ -13442,7 +13147,7 @@
         "packages/eslint-config-vue": {
             "name": "@tada5hi/eslint-config-vue",
             "version": "2.0.1",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@tada5hi/eslint-config": "^2.0.1",
                 "eslint-plugin-vue": "^10.0.0"
@@ -13454,7 +13159,7 @@
         "packages/eslint-config-vue-typescript": {
             "name": "@tada5hi/eslint-config-vue-typescript",
             "version": "2.0.1",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@tada5hi/eslint-config": "^2.0.1",
                 "eslint-plugin-vue": "^10.0.0",
@@ -13495,7 +13200,7 @@
         "packages/prettier-config": {
             "name": "@tada5hi/prettier-config",
             "version": "1.3.1",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "dependencies": {
                 "prettier": "^3.8.1"
             }
@@ -13503,7 +13208,7 @@
         "packages/semantic-release": {
             "name": "@tada5hi/semantic-release",
             "version": "0.4.1",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/git": "^10.0.1"
@@ -13515,7 +13220,7 @@
         "packages/tsconfig": {
             "name": "@tada5hi/tsconfig",
             "version": "0.7.1",
-            "license": "MIT"
+            "license": "Apache-2.0"
         }
     }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -50,7 +50,7 @@
         "@antfu/install-pkg": "^1.1.0",
         "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.10.0",
-        "eslint-plugin-import-x": "^4.0.0",
+        "eslint-plugin-import-lite": "^0.6.0",
         "eslint-plugin-unicorn": "^63.0.0",
         "globals": "^17.4.0",
         "smob": "^1.6.1"

--- a/packages/eslint-config/src/configs/imports/module.ts
+++ b/packages/eslint-config/src/configs/imports/module.ts
@@ -6,53 +6,19 @@
  */
 
 import type { Linter } from 'eslint';
-import importXPlugin from 'eslint-plugin-import-x';
+import importLitePlugin from 'eslint-plugin-import-lite';
 
 export function imports(): Linter.Config[] {
     return [
         {
             plugins: {
-                'import-x': importXPlugin,
+                'import': importLitePlugin,
             },
             rules: {
-                'import-x/export': 'error',
-                'import-x/extensions': ['error', 'ignorePackages', {
-                    js: 'always',
-                    jsx: 'always',
-                    ts: 'always',
-                    tsx: 'always',
-                    mjs: 'always',
-                    mts: 'always',
-                    cts: 'always',
-                }],
-                'import-x/first': 'error',
-                'import-x/newline-after-import': 'error',
-                'import-x/no-absolute-path': 'error',
-                'import-x/no-cycle': 'error',
-                'import-x/no-duplicates': 'error',
-                'import-x/no-extraneous-dependencies': ['error', {
-                    devDependencies: [
-                        '**/test/**',
-                        '**/tests/**',
-                        '**/*.test.{js,ts}',
-                        '**/*.spec.{js,ts}',
-                        '**/vitest.config.*',
-                        '**/vite.config.*',
-                        '**/rollup.config.*',
-                        '**/eslint.config.*',
-                    ],
-                    optionalDependencies: false,
-                }],
-                'import-x/no-mutable-exports': 'error',
-                'import-x/no-relative-packages': 'off',
-                'import-x/no-self-import': 'error',
-                'import-x/no-useless-path-segments': 'error',
-                'import-x/no-webpack-loader-syntax': 'error',
-                'import-x/order': ['error', {
-                    groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
-                }],
-                'import-x/prefer-default-export': 'off',
-                'import-x/no-unresolved': 'off',
+                'import/first': 'error',
+                'import/newline-after-import': 'error',
+                'import/no-duplicates': 'error',
+                'import/no-mutable-exports': 'error',
 
                 'sort-imports': ['error', {
                     ignoreCase: false,

--- a/packages/eslint-config/test/data/ts/src/index.ts
+++ b/packages/eslint-config/test/data/ts/src/index.ts
@@ -1,0 +1,5 @@
+import { add } from './utils.ts';
+
+const result = add(1, 2);
+
+export default result;

--- a/packages/eslint-config/test/data/ts/src/utils.ts
+++ b/packages/eslint-config/test/data/ts/src/utils.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+    return a + b;
+}

--- a/packages/eslint-config/test/data/ts/tsconfig.json
+++ b/packages/eslint-config/test/data/ts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "strict": true,
+        "esModuleInterop": true,
+        "allowImportingTsExtensions": true,
+        "noEmit": true
+    },
+    "include": ["src"]
+}

--- a/packages/eslint-config/test/data/vue/src/App.vue
+++ b/packages/eslint-config/test/data/vue/src/App.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { greet } from './utils.ts';
+
+const message = greet('World');
+</script>
+
+<template>
+    <div>{{ message }}</div>
+</template>

--- a/packages/eslint-config/test/data/vue/src/utils.ts
+++ b/packages/eslint-config/test/data/vue/src/utils.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+    return `Hello, ${name}!`;
+}

--- a/packages/eslint-config/test/data/vue/tsconfig.json
+++ b/packages/eslint-config/test/data/vue/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "strict": true,
+        "esModuleInterop": true,
+        "allowImportingTsExtensions": true,
+        "noEmit": true
+    },
+    "include": ["src"]
+}

--- a/packages/eslint-config/test/unit/imports.spec.ts
+++ b/packages/eslint-config/test/unit/imports.spec.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { Linter } from 'eslint';
+import eslintConfig from '../../src/index.ts';
+
+const dataDir = resolve(import.meta.dirname, '..', 'data');
+
+describe('import rules', () => {
+    it('should include import plugin', async () => {
+        const config = await eslintConfig({ typescript: false, vue: false });
+        const hasPlugin = config.some(
+            (c: any) => c.plugins && ('import' in c.plugins),
+        );
+        expect(hasPlugin).toBe(true);
+    });
+
+    it('should lint typescript files without resolver error', async () => {
+        const linter = new Linter();
+        const config = await eslintConfig({ typescript: true, vue: false });
+
+        const code = readFileSync(resolve(dataDir, 'ts/src/index.ts'), 'utf-8');
+        const messages = linter.verify(
+            code,
+            config,
+            { filename: resolve(dataDir, 'ts/src/index.ts') },
+        );
+
+        const resolverErrors = messages.filter(
+            (m) => m.message.includes('resolver') || m.message.includes('Resolve error'),
+        );
+        expect(resolverErrors).toHaveLength(0);
+    });
+
+    it('should lint vue + typescript files without resolver error', async () => {
+        const linter = new Linter();
+        const config = await eslintConfig({ typescript: true, vue: true });
+
+        const code = readFileSync(resolve(dataDir, 'vue/src/App.vue'), 'utf-8');
+        const messages = linter.verify(
+            code,
+            config,
+            { filename: resolve(dataDir, 'vue/src/App.vue') },
+        );
+
+        const resolverErrors = messages.filter(
+            (m) => m.message.includes('resolver') || m.message.includes('Resolve error'),
+        );
+        expect(resolverErrors).toHaveLength(0);
+    });
+
+    it('should enforce imports-first', async () => {
+        const linter = new Linter();
+        const config = await eslintConfig({ typescript: false, vue: false });
+
+        const messages = linter.verify(
+            'const x = 1;\nimport { foo } from \'bar\';\n',
+            config,
+            { filename: 'test.js' },
+        );
+        const error = messages.find((m) => m.ruleId === 'import/first');
+        expect(error).toBeDefined();
+    });
+
+    it('should enforce no-duplicate-imports', async () => {
+        const linter = new Linter();
+        const config = await eslintConfig({ typescript: false, vue: false });
+
+        const messages = linter.verify(
+            'import { foo } from \'bar\';\nimport { baz } from \'bar\';\n',
+            config,
+            { filename: 'test.js' },
+        );
+        const error = messages.find((m) => m.ruleId === 'import/no-duplicates');
+        expect(error).toBeDefined();
+    });
+});


### PR DESCRIPTION
resolves #881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint import plugin dependency to a new version.

* **Tests**
  * Added unit tests to validate ESLint configuration behavior with TypeScript and Vue projects.
  * Added test fixtures for TypeScript and Vue project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->